### PR TITLE
[hotfix] revises external topnav link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,6 @@ ex. `/src/components/SomeComponent/index.js`
 Briefly describe how to setup the demo env, and how to run the application in
 such a way as to observe the results of the work included in this PR.
 
-## BREAKING CHANGES
-
-Describe any _breaking changes_ here. Breaking changes will trigger a major
-version bump.
-
 ## ANY NEW DEPENDENCIES ADDED?
 
 List any new dependencies added.

--- a/src/blocks/TopNav/A.js
+++ b/src/blocks/TopNav/A.js
@@ -1,0 +1,5 @@
+import { buildStyledComponent } from 'utils';
+
+import Link from './Link';
+
+export default buildStyledComponent('TopNav__A', Link.withComponent('a'));

--- a/src/blocks/TopNav/index.js
+++ b/src/blocks/TopNav/index.js
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components';
 
 import { buildStyledComponent } from 'utils';
 
+import A from './A';
 import Link from './Link';
 import LinkList from './LinkList';
 import LinkListItem from './LinkListItem';
@@ -16,6 +17,7 @@ const styles = ({ theme }) => css`
 
 const TopNav = buildStyledComponent('TopNav', styled.nav, styles);
 
+TopNav.A = A;
 TopNav.Link = Link;
 TopNav.LinkList = LinkList;
 TopNav.LinkListItem = LinkListItem;

--- a/src/components/TopNav/index.js
+++ b/src/components/TopNav/index.js
@@ -17,12 +17,12 @@ function TopNav() {
       </StyledTopNav.LinkList>
       <StyledTopNav.LinkList>
         <StyledTopNav.LinkListItem>
-          <StyledTopNav.Link
-            to="https://github.com/andrewtpoe/react-companies"
+          <StyledTopNav.A
+            href="https://github.com/andrewtpoe/react-companies"
             modifiers={['textWhite']}
           >
             <Icon className="fab fa-lg fa-github" />
-          </StyledTopNav.Link>
+          </StyledTopNav.A>
         </StyledTopNav.LinkListItem>
       </StyledTopNav.LinkList>
     </StyledTopNav>


### PR DESCRIPTION
## ISSUE

none

## DESCRIPTION

During QA review, it was observed that the github link in the top nav was internally directed.

## WHERE SHOULD THE REVIEWER START?

src/components/TopNav/index.js

## HOW CAN THIS BE TESTED?

pull it, run it, click on the GH link in the top nav and observe you are actually taken to GH.

## ANY NEW DEPENDENCIES ADDED?

no

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

* [x] I rebased this branch on the `master` branch
